### PR TITLE
Update jackknife to use jackknife mean rather than full sample mean

### DIFF
--- a/R/StaggeredSynthDiD.R
+++ b/R/StaggeredSynthDiD.R
@@ -138,7 +138,7 @@ StaggeredSynthDiD <- function(data, unit = "Unit", time = "Time",
     })
 
     # compute variance
-    V_hat <- (N - 1) * mean((taus_jack - tau_hat)^2)
+    V_hat <- (N - 1) * mean((taus_jack - mean(taus_jack, na.rm = TRUE))^2)
   }
 
   # placebo variance estimator


### PR DESCRIPTION
Arkhangelsky et al. use the full sample mean in their modified jackknife procedure because they use the same lambda and omega for each resample. However, this implementation recalculates new weights for each resample, which is the usual jackknife (not the same as Arkhangelsky et al.). Therefore, the jackknife mean rather than the full sample mean should be subtracted from each jackknife estimate.